### PR TITLE
Initialize Paper plugin scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target/
+*.iml
+.idea/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Repository Guidelines
+
+- This repository hosts a PaperMC plugin project built with Maven.
+- Keep Java source under `src/main/java`, organized by package (`com.example.tinyhunt` unless the scope requires otherwise).
+- Resource files (e.g., `plugin.yml`) belong in `src/main/resources`.
+- Prefer descriptive class names and JavaDoc for new public APIs.
+- Avoid embedding CSS or JavaScript directly in HTML templates within this repository.
+- Update this file with any additional conventions as the project evolves.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,61 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>tinyhunt-plugin</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>TinyHunt Plugin</name>
+    <description>Paper plugin for TinyHunt server</description>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>papermc-repo</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.20.4-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <release>17</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.4.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/tinyhunt/TinyHuntPlugin.java
+++ b/src/main/java/com/example/tinyhunt/TinyHuntPlugin.java
@@ -1,0 +1,19 @@
+package com.example.tinyhunt;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Entry point for the TinyHunt Paper plugin.
+ */
+public final class TinyHuntPlugin extends JavaPlugin {
+
+    @Override
+    public void onEnable() {
+        getLogger().info("TinyHunt plugin enabled.");
+    }
+
+    @Override
+    public void onDisable() {
+        getLogger().info("TinyHunt plugin disabled.");
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,7 @@
+name: TinyHunt
+main: com.example.tinyhunt.TinyHuntPlugin
+version: 0.0.1
+api-version: "1.20"
+authors:
+  - TinyHunt Team
+description: Base structure for the TinyHunt Paper plugin.


### PR DESCRIPTION
## Summary
- add repository guidelines via AGENTS.md
- configure Maven project with Paper API dependency
- scaffold TinyHunt plugin entrypoint and plugin.yml metadata

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e51e1f72148320939bac36cb194d27