### PR TITLE
Implement TinyHunt lobby and minigame management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,12 @@
 # Repository Guidelines
-
 - This repository hosts a PaperMC plugin project built with Maven.
 - Keep Java source under `src/main/java`, organized by package (`com.example.tinyhunt` unless the scope requires otherwise).
-- Resource files (e.g., `plugin.yml`) belong in `src/main/resources`.
+- Resource files (e.g., `plugin.yml`, `config.yml`) belong in `src/main/resources`.
 - Prefer descriptive class names and JavaDoc for new public APIs.
 - Avoid embedding CSS or JavaScript directly in HTML templates within this repository.
-- Update this file with any additional conventions as the project evolves.
+- The `com.example.tinyhunt` package is organized into three sub-packages:
+  - `command` for Bukkit command executors and tab completers.
+  - `game` for game flow controllers, state, and listeners.
+  - `model` for serializable representations such as areas or player roles.
+- When adding new commands, wire them through the central `TinyHuntCommand` class and keep permission keys consistent with the pattern `tinyhunt.<action>`.
+- Persist game configuration (areas, spawns, numeric settings) via the plugin config to allow administrators to tweak values without rebuilding.

--- a/src/main/java/com/example/tinyhunt/TinyHuntPlugin.java
+++ b/src/main/java/com/example/tinyhunt/TinyHuntPlugin.java
@@ -1,5 +1,13 @@
 package com.example.tinyhunt;
 
+import com.example.tinyhunt.command.TinyHuntCommand;
+import com.example.tinyhunt.game.GameManager;
+import com.example.tinyhunt.game.PlayerListener;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import org.bukkit.ChatColor;
+import org.bukkit.command.PluginCommand;
 import org.bukkit.plugin.java.JavaPlugin;
 
 /**
@@ -7,13 +15,47 @@ import org.bukkit.plugin.java.JavaPlugin;
  */
 public final class TinyHuntPlugin extends JavaPlugin {
 
+    private GameManager gameManager;
+
     @Override
     public void onEnable() {
+        saveDefaultConfig();
+        gameManager = new GameManager(this);
+        TinyHuntCommand tinyHuntCommand = new TinyHuntCommand(this, gameManager);
+        PluginCommand command = Objects.requireNonNull(getCommand("tinyhunt"),
+                "tinyhunt command must be defined in plugin.yml");
+        command.setExecutor(tinyHuntCommand);
+        command.setTabCompleter(tinyHuntCommand);
+        getServer().getPluginManager().registerEvents(new PlayerListener(gameManager), this);
         getLogger().info("TinyHunt plugin enabled.");
     }
 
     @Override
     public void onDisable() {
+        if (gameManager != null) {
+            gameManager.cancelAllTasks();
+        }
         getLogger().info("TinyHunt plugin disabled.");
+    }
+
+    public GameManager getGameManager() {
+        return gameManager;
+    }
+
+    public String getMessage(String path) {
+        String raw = getConfig().getString(path, path);
+        return ChatColor.translateAlternateColorCodes('&', raw);
+    }
+
+    public String getMessage(String path, Map<String, ?> placeholders) {
+        String message = getMessage(path);
+        if (placeholders == null || placeholders.isEmpty()) {
+            return message;
+        }
+        for (Entry<String, ?> entry : placeholders.entrySet()) {
+            String token = "%" + entry.getKey() + "%";
+            message = message.replace(token, String.valueOf(entry.getValue()));
+        }
+        return message;
     }
 }

--- a/src/main/java/com/example/tinyhunt/command/TinyHuntCommand.java
+++ b/src/main/java/com/example/tinyhunt/command/TinyHuntCommand.java
@@ -1,0 +1,203 @@
+package com.example.tinyhunt.command;
+
+import com.example.tinyhunt.TinyHuntPlugin;
+import com.example.tinyhunt.game.GameManager;
+import com.example.tinyhunt.game.GameState;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+/**
+ * Handles the `/tinyhunt` root command and associated sub-commands.
+ */
+public final class TinyHuntCommand implements CommandExecutor, TabCompleter {
+
+    private final TinyHuntPlugin plugin;
+    private final GameManager gameManager;
+
+    public TinyHuntCommand(TinyHuntPlugin plugin, GameManager gameManager) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        this.gameManager = Objects.requireNonNull(gameManager, "gameManager");
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) {
+            sender.sendMessage(plugin.getMessage("messages.command-help"));
+            return true;
+        }
+        String sub = args[0].toLowerCase(Locale.ROOT);
+        switch (sub) {
+            case "join" -> handleJoin(sender);
+            case "leave" -> handleLeave(sender);
+            case "start" -> handleStart(sender);
+            case "stop" -> handleStop(sender);
+            case "reload" -> handleReload(sender);
+            case "lobby" -> handleLobby(sender, args);
+            case "arena" -> handleArena(sender, args);
+            default -> sender.sendMessage(plugin.getMessage("messages.unknown-subcommand"));
+        }
+        return true;
+    }
+
+    private void handleJoin(CommandSender sender) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(plugin.getMessage("messages.player-only"));
+            return;
+        }
+        if (!sender.hasPermission("tinyhunt.play")) {
+            sender.sendMessage(plugin.getMessage("messages.no-permission"));
+            return;
+        }
+        gameManager.enqueue(player);
+    }
+
+    private void handleLeave(CommandSender sender) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(plugin.getMessage("messages.player-only"));
+            return;
+        }
+        if (!sender.hasPermission("tinyhunt.play")) {
+            sender.sendMessage(plugin.getMessage("messages.no-permission"));
+            return;
+        }
+        gameManager.leaveQueue(player);
+    }
+
+    private void handleStart(CommandSender sender) {
+        if (!sender.hasPermission("tinyhunt.admin")) {
+            sender.sendMessage(plugin.getMessage("messages.no-permission"));
+            return;
+        }
+        if (gameManager.getState() == GameState.RUNNING) {
+            sender.sendMessage(plugin.getMessage("messages.already-running"));
+            return;
+        }
+        if (gameManager.forceStart()) {
+            sender.sendMessage(plugin.getMessage("messages.start-requested"));
+        } else {
+            sender.sendMessage(plugin.getMessage("messages.not-enough-players"));
+        }
+    }
+
+    private void handleStop(CommandSender sender) {
+        if (!sender.hasPermission("tinyhunt.admin")) {
+            sender.sendMessage(plugin.getMessage("messages.no-permission"));
+            return;
+        }
+        if (gameManager.stopManually()) {
+            sender.sendMessage(plugin.getMessage("messages.stop-requested"));
+        } else {
+            sender.sendMessage(plugin.getMessage("messages.no-active-game"));
+        }
+    }
+
+    private void handleReload(CommandSender sender) {
+        if (!sender.hasPermission("tinyhunt.admin")) {
+            sender.sendMessage(plugin.getMessage("messages.no-permission"));
+            return;
+        }
+        gameManager.reloadSettings();
+        sender.sendMessage(plugin.getMessage("messages.reloaded"));
+    }
+
+    private void handleLobby(CommandSender sender, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(plugin.getMessage("messages.player-only"));
+            return;
+        }
+        if (!sender.hasPermission("tinyhunt.admin")) {
+            sender.sendMessage(plugin.getMessage("messages.no-permission"));
+            return;
+        }
+        if (args.length < 2) {
+            sender.sendMessage(plugin.getMessage("messages.usage-lobby"));
+            return;
+        }
+        switch (args[1].toLowerCase(Locale.ROOT)) {
+            case "setpos1" -> {
+                gameManager.saveLobbyCorner(player.getLocation(), true);
+                sender.sendMessage(plugin.getMessage("messages.lobby-pos-set", Map.of("corner", 1)));
+            }
+            case "setpos2" -> {
+                gameManager.saveLobbyCorner(player.getLocation(), false);
+                sender.sendMessage(plugin.getMessage("messages.lobby-pos-set", Map.of("corner", 2)));
+            }
+            default -> sender.sendMessage(plugin.getMessage("messages.usage-lobby"));
+        }
+    }
+
+    private void handleArena(CommandSender sender, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(plugin.getMessage("messages.player-only"));
+            return;
+        }
+        if (!sender.hasPermission("tinyhunt.admin")) {
+            sender.sendMessage(plugin.getMessage("messages.no-permission"));
+            return;
+        }
+        if (args.length < 2) {
+            sender.sendMessage(plugin.getMessage("messages.usage-arena"));
+            return;
+        }
+        switch (args[1].toLowerCase(Locale.ROOT)) {
+            case "setpos1" -> {
+                gameManager.saveArenaCorner(player.getLocation(), true);
+                sender.sendMessage(plugin.getMessage("messages.arena-pos-set", Map.of("corner", 1)));
+            }
+            case "setpos2" -> {
+                gameManager.saveArenaCorner(player.getLocation(), false);
+                sender.sendMessage(plugin.getMessage("messages.arena-pos-set", Map.of("corner", 2)));
+            }
+            case "addspawn" -> {
+                gameManager.addArenaSpawn(player.getLocation());
+                sender.sendMessage(plugin.getMessage("messages.arena-spawn-added"));
+            }
+            default -> sender.sendMessage(plugin.getMessage("messages.usage-arena"));
+        }
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (args.length == 1) {
+            List<String> options = new ArrayList<>();
+            if (sender.hasPermission("tinyhunt.play")) {
+                options.add("join");
+                options.add("leave");
+            }
+            if (sender.hasPermission("tinyhunt.admin")) {
+                options.addAll(Arrays.asList("start", "stop", "reload", "lobby", "arena"));
+            }
+            return partialMatches(args[0], options);
+        }
+        if (args.length == 2) {
+            if ("lobby".equalsIgnoreCase(args[0]) && sender.hasPermission("tinyhunt.admin")) {
+                return partialMatches(args[1], Arrays.asList("setpos1", "setpos2"));
+            }
+            if ("arena".equalsIgnoreCase(args[0]) && sender.hasPermission("tinyhunt.admin")) {
+                return partialMatches(args[1], Arrays.asList("setpos1", "setpos2", "addspawn"));
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    private List<String> partialMatches(String token, List<String> options) {
+        String lower = token.toLowerCase(Locale.ROOT);
+        List<String> matches = new ArrayList<>();
+        for (String option : options) {
+            if (option.toLowerCase(Locale.ROOT).startsWith(lower)) {
+                matches.add(option);
+            }
+        }
+        return matches;
+    }
+}

--- a/src/main/java/com/example/tinyhunt/game/GameEndReason.java
+++ b/src/main/java/com/example/tinyhunt/game/GameEndReason.java
@@ -1,0 +1,11 @@
+package com.example.tinyhunt.game;
+
+/**
+ * Reasons for concluding a match.
+ */
+public enum GameEndReason {
+    HUNTERS_ELIMINATED_ALL,
+    RUNNERS_SURVIVED,
+    MANUAL_STOP,
+    CONFIGURATION_ERROR;
+}

--- a/src/main/java/com/example/tinyhunt/game/GameManager.java
+++ b/src/main/java/com/example/tinyhunt/game/GameManager.java
@@ -1,0 +1,555 @@
+package com.example.tinyhunt.game;
+
+import com.example.tinyhunt.TinyHuntPlugin;
+import com.example.tinyhunt.model.ConfigLocationUtil;
+import com.example.tinyhunt.model.ConfiguredArea;
+import com.example.tinyhunt.model.PlayerRole;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+
+/**
+ * Coordinates queue management, game flow, and configuration-backed state.
+ */
+public final class GameManager {
+
+    private final TinyHuntPlugin plugin;
+    private ConfiguredArea lobbyArea;
+    private ConfiguredArea arenaArea;
+    private final List<Location> arenaSpawns = new ArrayList<>();
+
+    private final LinkedHashSet<UUID> queue = new LinkedHashSet<>();
+    private final LinkedHashSet<UUID> activePlayers = new LinkedHashSet<>();
+    private final Map<UUID, PlayerRole> roles = new HashMap<>();
+
+    private GameState state = GameState.WAITING;
+    private BukkitTask countdownTask;
+    private int countdownSecondsRemaining;
+    private BukkitTask hunterSelectionTask;
+    private BukkitTask gameTimerTask;
+
+    private int minPlayers;
+    private int maxPlayers;
+    private int autoStartSeconds;
+    private int hunterDelaySeconds;
+    private int gameDurationSeconds;
+    private float runnerScale;
+    private float hunterScale;
+    private Attribute cachedScaleAttribute;
+    private boolean scaleAttributeResolved;
+    private boolean scaleWarningLogged;
+
+    public GameManager(TinyHuntPlugin plugin) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        reloadSettings();
+    }
+
+    public void reloadSettings() {
+        plugin.reloadConfig();
+        minPlayers = Math.max(2, plugin.getConfig().getInt("players.min", 4));
+        maxPlayers = Math.max(minPlayers, plugin.getConfig().getInt("players.max", minPlayers));
+        autoStartSeconds = Math.max(5, plugin.getConfig().getInt("timers.auto-start-seconds", 120));
+        hunterDelaySeconds = Math.max(1, plugin.getConfig().getInt("timers.hunter-selection-seconds", 10));
+        gameDurationSeconds = Math.max(30, plugin.getConfig().getInt("timers.game-duration-seconds", 600));
+        runnerScale = (float) plugin.getConfig().getDouble("scales.runner", 0.33D);
+        hunterScale = (float) plugin.getConfig().getDouble("scales.hunter", 1.0D);
+
+        lobbyArea = ConfiguredArea.load(plugin.getConfig().getConfigurationSection("areas.lobby"));
+        arenaArea = ConfiguredArea.load(plugin.getConfig().getConfigurationSection("areas.arena"));
+
+        arenaSpawns.clear();
+        arenaSpawns.addAll(ConfigLocationUtil
+                .readLocationList(plugin.getConfig().getConfigurationSection("arena-spawns")));
+    }
+
+    public GameState getState() {
+        return state;
+    }
+
+    public int getMinPlayers() {
+        return minPlayers;
+    }
+
+    public int getMaxPlayers() {
+        return maxPlayers;
+    }
+
+    public ConfiguredArea getLobbyArea() {
+        return lobbyArea;
+    }
+
+    public ConfiguredArea getArenaArea() {
+        return arenaArea;
+    }
+
+    public List<Location> getArenaSpawns() {
+        return new ArrayList<>(arenaSpawns);
+    }
+
+    public boolean isInQueue(Player player) {
+        return queue.contains(player.getUniqueId());
+    }
+
+    public boolean isParticipant(Player player) {
+        return activePlayers.contains(player.getUniqueId());
+    }
+
+    public boolean isHunter(Player player) {
+        return roles.getOrDefault(player.getUniqueId(), PlayerRole.RUNNER) == PlayerRole.HUNTER;
+    }
+
+    public void enqueue(Player player) {
+        if (!state.canJoin()) {
+            player.sendMessage(plugin.getMessage("messages.cannot-join"));
+            return;
+        }
+        if (queue.contains(player.getUniqueId())) {
+            player.sendMessage(plugin.getMessage("messages.already-queued"));
+            return;
+        }
+        if (queue.size() >= maxPlayers) {
+            player.sendMessage(plugin.getMessage("messages.queue-full"));
+            return;
+        }
+        queue.add(player.getUniqueId());
+        player.sendMessage(plugin.getMessage("messages.joined-queue", Map.of("position", queue.size())));
+        checkAutoStart();
+    }
+
+    public void leaveQueue(Player player) {
+        if (queue.remove(player.getUniqueId())) {
+            player.sendMessage(plugin.getMessage("messages.left-queue"));
+            if (state == GameState.COUNTDOWN && queue.size() < minPlayers) {
+                cancelCountdown();
+                broadcastToQueue(plugin.getMessage("messages.countdown-cancelled"));
+            }
+            return;
+        }
+        if (isParticipant(player)) {
+            eliminatePlayer(player, false);
+        } else {
+            player.sendMessage(plugin.getMessage("messages.not-in-queue"));
+        }
+    }
+
+    public void checkAutoStart() {
+        if (state != GameState.WAITING) {
+            return;
+        }
+        if (queue.size() < minPlayers) {
+            return;
+        }
+        startCountdown();
+    }
+
+    public void startCountdown() {
+        if (state == GameState.COUNTDOWN || state == GameState.RUNNING) {
+            return;
+        }
+        if (queue.size() < minPlayers) {
+            return;
+        }
+        state = GameState.COUNTDOWN;
+        countdownSecondsRemaining = autoStartSeconds;
+        broadcastToQueue(plugin.getMessage("messages.countdown-start",
+                Map.of("seconds", countdownSecondsRemaining)));
+        countdownTask = new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (countdownSecondsRemaining <= 0) {
+                    cancel();
+                    beginMatch();
+                    return;
+                }
+                if (queue.size() < minPlayers) {
+                    broadcastToQueue(plugin.getMessage("messages.countdown-cancelled"));
+                    cancelCountdown();
+                    return;
+                }
+                if (countdownSecondsRemaining <= 10 || countdownSecondsRemaining % 30 == 0) {
+                    broadcastToQueue(plugin.getMessage("messages.countdown-tick",
+                            Map.of("seconds", countdownSecondsRemaining)));
+                }
+                countdownSecondsRemaining--;
+            }
+        }.runTaskTimer(plugin, 20L, 20L);
+    }
+
+    public boolean forceStart() {
+        if (state == GameState.RUNNING) {
+            return false;
+        }
+        if (queue.size() < minPlayers) {
+            broadcastToQueue(plugin.getMessage("messages.not-enough-players"));
+            return false;
+        }
+        beginMatch();
+        return true;
+    }
+
+    private void beginMatch() {
+        cancelCountdown();
+        if (!validateConfiguration()) {
+            broadcastToQueue(plugin.getMessage("messages.configuration-missing"));
+            state = GameState.WAITING;
+            return;
+        }
+        state = GameState.RUNNING;
+        roles.clear();
+        activePlayers.clear();
+        for (UUID uuid : queue) {
+            Player player = Bukkit.getPlayer(uuid);
+            if (player != null && player.isOnline()) {
+                activePlayers.add(uuid);
+            }
+        }
+        queue.clear();
+        if (activePlayers.size() < minPlayers) {
+            broadcastToQueue(plugin.getMessage("messages.not-enough-players"));
+            state = GameState.WAITING;
+            return;
+        }
+        for (UUID uuid : activePlayers) {
+            Player player = Bukkit.getPlayer(uuid);
+            if (player != null) {
+                roles.put(uuid, PlayerRole.RUNNER);
+                applyRunnerState(player);
+                teleportToArena(player);
+                player.sendMessage(plugin.getMessage("messages.game-start-runner"));
+            }
+        }
+        broadcastToParticipants(plugin.getMessage("messages.game-start"));
+        scheduleHunterSelection();
+        scheduleGameTimer();
+    }
+
+    private void scheduleHunterSelection() {
+        cancelHunterSelection();
+        hunterSelectionTask = new BukkitRunnable() {
+            @Override
+            public void run() {
+                selectRandomHunter();
+            }
+        }.runTaskLater(plugin, hunterDelaySeconds * 20L);
+    }
+
+    private void scheduleGameTimer() {
+        cancelGameTimer();
+        gameTimerTask = new BukkitRunnable() {
+            @Override
+            public void run() {
+                concludeGame(GameEndReason.RUNNERS_SURVIVED);
+            }
+        }.runTaskLater(plugin, gameDurationSeconds * 20L);
+    }
+
+    public void selectRandomHunter() {
+        List<Player> runners = activePlayers.stream()
+                .map(Bukkit::getPlayer)
+                .filter(Objects::nonNull)
+                .filter(player -> roles.getOrDefault(player.getUniqueId(), PlayerRole.RUNNER) == PlayerRole.RUNNER)
+                .collect(Collectors.toList());
+        if (runners.isEmpty()) {
+            concludeGame(GameEndReason.CONFIGURATION_ERROR);
+            return;
+        }
+        Player chosen = runners.get(ThreadLocalRandom.current().nextInt(runners.size()));
+        promoteToHunter(chosen, true);
+        broadcastToParticipants(plugin.getMessage("messages.hunter-selected",
+                Map.of("player", chosen.getName())));
+    }
+
+    public void handleHunterHit(Player hunter, Player target) {
+        if (state != GameState.RUNNING) {
+            return;
+        }
+        if (!isHunter(hunter)) {
+            return;
+        }
+        if (!isParticipant(target)) {
+            return;
+        }
+        if (isHunter(target)) {
+            return;
+        }
+        promoteToHunter(target, false);
+        broadcastToParticipants(plugin.getMessage("messages.runner-converted",
+                Map.of("player", target.getName())));
+        if (getRemainingRunners().isEmpty()) {
+            concludeGame(GameEndReason.HUNTERS_ELIMINATED_ALL);
+        }
+    }
+
+    public void eliminatePlayer(Player player, boolean silent) {
+        roles.remove(player.getUniqueId());
+        activePlayers.remove(player.getUniqueId());
+        resetPlayerState(player);
+        teleportToLobby(player);
+        if (!silent) {
+            broadcastToParticipants(plugin.getMessage("messages.player-left",
+                    Map.of("player", player.getName())));
+        }
+        if (state == GameState.RUNNING && getRemainingRunners().isEmpty()) {
+            concludeGame(GameEndReason.HUNTERS_ELIMINATED_ALL);
+        }
+    }
+
+    public void handlePlayerQuit(Player player) {
+        UUID uuid = player.getUniqueId();
+        boolean removedFromQueue = queue.remove(uuid);
+        if (removedFromQueue && state == GameState.COUNTDOWN && queue.size() < minPlayers) {
+            cancelCountdown();
+            broadcastToQueue(plugin.getMessage("messages.countdown-cancelled"));
+        }
+        if (activePlayers.remove(uuid)) {
+            roles.remove(uuid);
+            if (state == GameState.RUNNING && getRemainingRunners().isEmpty()) {
+                concludeGame(GameEndReason.HUNTERS_ELIMINATED_ALL);
+            }
+        }
+    }
+
+    public void concludeGame(GameEndReason reason) {
+        if (state != GameState.RUNNING && state != GameState.COUNTDOWN) {
+            return;
+        }
+        cancelCountdown();
+        cancelHunterSelection();
+        cancelGameTimer();
+        state = GameState.ENDING;
+        String message = switch (reason) {
+            case HUNTERS_ELIMINATED_ALL -> plugin.getMessage("messages.hunters-win");
+            case RUNNERS_SURVIVED -> plugin.getMessage("messages.runners-win");
+            case MANUAL_STOP -> plugin.getMessage("messages.manual-stop");
+            case CONFIGURATION_ERROR -> plugin.getMessage("messages.configuration-missing");
+        };
+        broadcastToParticipants(message);
+        for (UUID uuid : new ArrayList<>(activePlayers)) {
+            Player player = Bukkit.getPlayer(uuid);
+            if (player != null) {
+                resetPlayerState(player);
+                teleportToLobby(player);
+            }
+        }
+        activePlayers.clear();
+        roles.clear();
+        state = GameState.WAITING;
+    }
+
+    public boolean stopManually() {
+        if (state == GameState.WAITING) {
+            return false;
+        }
+        if (state == GameState.COUNTDOWN) {
+            cancelCountdown();
+            broadcastToQueue(plugin.getMessage("messages.countdown-cancelled"));
+            return true;
+        }
+        concludeGame(GameEndReason.MANUAL_STOP);
+        return true;
+    }
+
+    private void teleportToArena(Player player) {
+        Location target = pickArenaSpawn().orElseGet(() -> arenaArea.getRandomLocation());
+        player.teleport(target);
+    }
+
+    private Optional<Location> pickArenaSpawn() {
+        if (arenaSpawns.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(arenaSpawns.get(ThreadLocalRandom.current().nextInt(arenaSpawns.size())));
+    }
+
+    private void teleportToLobby(Player player) {
+        if (lobbyArea != null && lobbyArea.isComplete()) {
+            player.teleport(lobbyArea.getCenter());
+        } else {
+            player.teleport(player.getWorld().getSpawnLocation());
+        }
+    }
+
+    private void applyRunnerState(Player player) {
+        applyScale(player, runnerScale);
+        player.setHealth(Math.min(player.getHealth(), player.getMaxHealth()));
+        player.setFoodLevel(20);
+    }
+
+    private void promoteToHunter(Player player, boolean announce) {
+        roles.put(player.getUniqueId(), PlayerRole.HUNTER);
+        applyScale(player, hunterScale);
+        teleportToArena(player);
+        if (announce) {
+            player.sendMessage(plugin.getMessage("messages.you-are-hunter"));
+        } else {
+            player.sendMessage(plugin.getMessage("messages.now-hunter"));
+        }
+    }
+
+    private void resetPlayerState(Player player) {
+        applyScale(player, 1.0F);
+    }
+
+    private List<Player> getRemainingRunners() {
+        return activePlayers.stream()
+                .map(Bukkit::getPlayer)
+                .filter(Objects::nonNull)
+                .filter(player -> roles.getOrDefault(player.getUniqueId(), PlayerRole.RUNNER) == PlayerRole.RUNNER)
+                .collect(Collectors.toList());
+    }
+
+    private boolean validateConfiguration() {
+        return lobbyArea != null && lobbyArea.isComplete() && arenaArea != null && arenaArea.isComplete()
+                && !arenaSpawns.isEmpty();
+    }
+
+    public void cancelAllTasks() {
+        cancelCountdown();
+        cancelHunterSelection();
+        cancelGameTimer();
+    }
+
+    private void cancelCountdown() {
+        if (countdownTask != null) {
+            countdownTask.cancel();
+            countdownTask = null;
+        }
+        if (state == GameState.COUNTDOWN) {
+            state = GameState.WAITING;
+        }
+    }
+
+    private void cancelHunterSelection() {
+        if (hunterSelectionTask != null) {
+            hunterSelectionTask.cancel();
+            hunterSelectionTask = null;
+        }
+    }
+
+    private void cancelGameTimer() {
+        if (gameTimerTask != null) {
+            gameTimerTask.cancel();
+            gameTimerTask = null;
+        }
+    }
+
+    private void broadcastToQueue(String message) {
+        broadcast(queue, message);
+    }
+
+    private void broadcastToParticipants(String message) {
+        broadcast(activePlayers, message);
+    }
+
+    private void broadcast(Collection<UUID> recipients, String message) {
+        for (UUID uuid : recipients) {
+            Player player = Bukkit.getPlayer(uuid);
+            if (player != null && message != null) {
+                player.sendMessage(message);
+            }
+        }
+    }
+
+    public void saveLobbyCorner(Location location, boolean first) {
+        if (lobbyArea == null) {
+            lobbyArea = new ConfiguredArea();
+        }
+        if (first) {
+            lobbyArea.setPos1(location);
+        } else {
+            lobbyArea.setPos2(location);
+        }
+        persistAreas();
+    }
+
+    public void saveArenaCorner(Location location, boolean first) {
+        if (arenaArea == null) {
+            arenaArea = new ConfiguredArea();
+        }
+        if (first) {
+            arenaArea.setPos1(location);
+        } else {
+            arenaArea.setPos2(location);
+        }
+        persistAreas();
+    }
+
+    public void addArenaSpawn(Location location) {
+        arenaSpawns.add(location);
+        persistArenaSpawns();
+    }
+
+    private void persistAreas() {
+        ConfigurationSection areas = plugin.getConfig().getConfigurationSection("areas");
+        if (areas == null) {
+            areas = plugin.getConfig().createSection("areas");
+        }
+        ConfigurationSection lobbySection = areas.getConfigurationSection("lobby");
+        if (lobbySection == null) {
+            lobbySection = areas.createSection("lobby");
+        }
+        ConfigurationSection arenaSection = areas.getConfigurationSection("arena");
+        if (arenaSection == null) {
+            arenaSection = areas.createSection("arena");
+        }
+        if (lobbyArea != null) {
+            lobbyArea.save(lobbySection);
+        }
+        if (arenaArea != null) {
+            arenaArea.save(arenaSection);
+        }
+        plugin.saveConfig();
+    }
+
+    private void persistArenaSpawns() {
+        ConfigurationSection spawns = plugin.getConfig().getConfigurationSection("arena-spawns");
+        if (spawns == null) {
+            spawns = plugin.getConfig().createSection("arena-spawns");
+        }
+        ConfigLocationUtil.writeLocationList(spawns, arenaSpawns);
+        plugin.saveConfig();
+    }
+
+    private void applyScale(Player player, float scale) {
+        Attribute attribute = resolveScaleAttribute();
+        if (attribute == null) {
+            return;
+        }
+        AttributeInstance instance = player.getAttribute(attribute);
+        if (instance != null) {
+            instance.setBaseValue(scale);
+        }
+    }
+
+    private Attribute resolveScaleAttribute() {
+        if (!scaleAttributeResolved) {
+            try {
+                cachedScaleAttribute = Attribute.valueOf("GENERIC_SCALE");
+            } catch (IllegalArgumentException ex) {
+                cachedScaleAttribute = null;
+                if (!scaleWarningLogged) {
+                    plugin.getLogger().warning("GENERIC_SCALE attribute not available; player scaling will be skipped.");
+                    scaleWarningLogged = true;
+                }
+            }
+            scaleAttributeResolved = true;
+        }
+        return cachedScaleAttribute;
+    }
+}

--- a/src/main/java/com/example/tinyhunt/game/GameState.java
+++ b/src/main/java/com/example/tinyhunt/game/GameState.java
@@ -1,0 +1,15 @@
+package com.example.tinyhunt.game;
+
+/**
+ * High-level game lifecycle.
+ */
+public enum GameState {
+    WAITING,
+    COUNTDOWN,
+    RUNNING,
+    ENDING;
+
+    public boolean canJoin() {
+        return this == WAITING || this == COUNTDOWN;
+    }
+}

--- a/src/main/java/com/example/tinyhunt/game/PlayerListener.java
+++ b/src/main/java/com/example/tinyhunt/game/PlayerListener.java
@@ -1,0 +1,49 @@
+package com.example.tinyhunt.game;
+
+import java.util.Objects;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+/**
+ * Handles runtime events affecting the TinyHunt game.
+ */
+public final class PlayerListener implements Listener {
+
+    private final GameManager gameManager;
+
+    public PlayerListener(GameManager gameManager) {
+        this.gameManager = Objects.requireNonNull(gameManager, "gameManager");
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        gameManager.handlePlayerQuit(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onDamage(EntityDamageByEntityEvent event) {
+        if (!(event.getDamager() instanceof Player damager)) {
+            return;
+        }
+        if (!(event.getEntity() instanceof Player victim)) {
+            return;
+        }
+        if (gameManager.getState() != GameState.RUNNING) {
+            return;
+        }
+        if (!gameManager.isHunter(damager)) {
+            return;
+        }
+        if (!gameManager.isParticipant(victim)) {
+            return;
+        }
+        if (gameManager.isHunter(victim)) {
+            return;
+        }
+        event.setCancelled(true);
+        gameManager.handleHunterHit(damager, victim);
+    }
+}

--- a/src/main/java/com/example/tinyhunt/model/ConfigLocationUtil.java
+++ b/src/main/java/com/example/tinyhunt/model/ConfigLocationUtil.java
@@ -1,0 +1,77 @@
+package com.example.tinyhunt.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.configuration.ConfigurationSection;
+
+/**
+ * Utility helpers for serializing locations into the plugin configuration.
+ */
+public final class ConfigLocationUtil {
+
+    private ConfigLocationUtil() {
+    }
+
+    public static void writeLocation(ConfigurationSection section, Location location) {
+        Objects.requireNonNull(section, "section");
+        Objects.requireNonNull(location, "location");
+        section.set("world", location.getWorld() != null ? location.getWorld().getName() : null);
+        section.set("x", location.getX());
+        section.set("y", location.getY());
+        section.set("z", location.getZ());
+        section.set("yaw", location.getYaw());
+        section.set("pitch", location.getPitch());
+    }
+
+    public static Location readLocation(ConfigurationSection section) {
+        if (section == null) {
+            return null;
+        }
+        String worldName = section.getString("world");
+        if (worldName == null) {
+            return null;
+        }
+        World world = Bukkit.getWorld(worldName);
+        if (world == null) {
+            return null;
+        }
+        double x = section.getDouble("x");
+        double y = section.getDouble("y");
+        double z = section.getDouble("z");
+        float yaw = (float) section.getDouble("yaw");
+        float pitch = (float) section.getDouble("pitch");
+        return new Location(world, x, y, z, yaw, pitch);
+    }
+
+    public static List<Location> readLocationList(ConfigurationSection section) {
+        if (section == null) {
+            return Collections.emptyList();
+        }
+        List<Location> locations = new ArrayList<>();
+        for (String key : section.getKeys(false)) {
+            Location location = readLocation(section.getConfigurationSection(key));
+            if (location != null) {
+                locations.add(location);
+            }
+        }
+        return locations;
+    }
+
+    public static void writeLocationList(ConfigurationSection section, List<Location> locations) {
+        Objects.requireNonNull(section, "section");
+        Objects.requireNonNull(locations, "locations");
+        for (String key : section.getKeys(false)) {
+            section.set(key, null);
+        }
+        for (int i = 0; i < locations.size(); i++) {
+            ConfigurationSection entry = section.createSection(String.valueOf(i));
+            writeLocation(entry, locations.get(i));
+        }
+    }
+}

--- a/src/main/java/com/example/tinyhunt/model/ConfiguredArea.java
+++ b/src/main/java/com/example/tinyhunt/model/ConfiguredArea.java
@@ -1,0 +1,152 @@
+package com.example.tinyhunt.model;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.util.Vector;
+
+/**
+ * Represents a cuboid area defined by two corner positions.
+ */
+public final class ConfiguredArea {
+
+    private Location pos1;
+    private Location pos2;
+
+    public Optional<Location> getPos1() {
+        return Optional.ofNullable(pos1);
+    }
+
+    public Optional<Location> getPos2() {
+        return Optional.ofNullable(pos2);
+    }
+
+    public void setPos1(Location location) {
+        this.pos1 = Objects.requireNonNull(location, "location");
+    }
+
+    public void setPos2(Location location) {
+        this.pos2 = Objects.requireNonNull(location, "location");
+    }
+
+    public boolean isComplete() {
+        return pos1 != null && pos2 != null && pos1.getWorld() != null && pos1.getWorld().equals(pos2.getWorld());
+    }
+
+    public World getWorld() {
+        if (!isComplete()) {
+            throw new IllegalStateException("Area is not fully configured");
+        }
+        return pos1.getWorld();
+    }
+
+    public Vector getMinimum() {
+        if (!isComplete()) {
+            throw new IllegalStateException("Area is not fully configured");
+        }
+        return new Vector(Math.min(pos1.getX(), pos2.getX()), Math.min(pos1.getY(), pos2.getY()),
+                Math.min(pos1.getZ(), pos2.getZ()));
+    }
+
+    public Vector getMaximum() {
+        if (!isComplete()) {
+            throw new IllegalStateException("Area is not fully configured");
+        }
+        return new Vector(Math.max(pos1.getX(), pos2.getX()), Math.max(pos1.getY(), pos2.getY()),
+                Math.max(pos1.getZ(), pos2.getZ()));
+    }
+
+    public Location getCenter() {
+        if (!isComplete()) {
+            throw new IllegalStateException("Area is not fully configured");
+        }
+        Vector min = getMinimum();
+        Vector max = getMaximum();
+        return new Location(getWorld(), (min.getX() + max.getX()) / 2.0, (min.getY() + max.getY()) / 2.0,
+                (min.getZ() + max.getZ()) / 2.0);
+    }
+
+    public Location getRandomLocation() {
+        if (!isComplete()) {
+            throw new IllegalStateException("Area is not fully configured");
+        }
+        Vector min = getMinimum();
+        Vector max = getMaximum();
+        double x = min.getX() + Math.random() * (max.getX() - min.getX());
+        double y = min.getY() + Math.random() * (max.getY() - min.getY());
+        double z = min.getZ() + Math.random() * (max.getZ() - min.getZ());
+        return new Location(getWorld(), x, y, z);
+    }
+
+    public void save(ConfigurationSection section) {
+        Objects.requireNonNull(section, "section");
+        if (!isComplete()) {
+            section.set("world", null);
+            section.set("pos1", null);
+            section.set("pos2", null);
+            return;
+        }
+        section.set("world", getWorld().getName());
+        ConfigurationSection pos1Section = getOrCreate(section, "pos1");
+        ConfigurationSection pos2Section = getOrCreate(section, "pos2");
+        setLocation(pos1Section, pos1);
+        setLocation(pos2Section, pos2);
+    }
+
+    public static ConfiguredArea load(ConfigurationSection section) {
+        ConfiguredArea area = new ConfiguredArea();
+        if (section == null) {
+            return area;
+        }
+        String worldName = section.getString("world");
+        if (worldName == null) {
+            return area;
+        }
+        World world = Bukkit.getWorld(worldName);
+        if (world == null) {
+            return area;
+        }
+        Location loadedPos1 = readLocation(section.getConfigurationSection("pos1"), world);
+        Location loadedPos2 = readLocation(section.getConfigurationSection("pos2"), world);
+        if (loadedPos1 != null && loadedPos2 != null) {
+            area.setPos1(loadedPos1);
+            area.setPos2(loadedPos2);
+        }
+        return area;
+    }
+
+    private static void setLocation(ConfigurationSection section, Location location) {
+        for (String key : section.getKeys(false)) {
+            section.set(key, null);
+        }
+        section.set("x", location.getX());
+        section.set("y", location.getY());
+        section.set("z", location.getZ());
+        section.set("yaw", location.getYaw());
+        section.set("pitch", location.getPitch());
+    }
+
+    private static ConfigurationSection getOrCreate(ConfigurationSection parent, String path) {
+        ConfigurationSection child = parent.getConfigurationSection(path);
+        if (child == null) {
+            child = parent.createSection(path);
+        }
+        return child;
+    }
+
+    private static Location readLocation(ConfigurationSection section, World fallbackWorld) {
+        if (section == null) {
+            return null;
+        }
+        double x = section.getDouble("x");
+        double y = section.getDouble("y");
+        double z = section.getDouble("z");
+        float yaw = (float) section.getDouble("yaw");
+        float pitch = (float) section.getDouble("pitch");
+        return new Location(fallbackWorld, x, y, z, yaw, pitch);
+    }
+}

--- a/src/main/java/com/example/tinyhunt/model/PlayerRole.java
+++ b/src/main/java/com/example/tinyhunt/model/PlayerRole.java
@@ -1,0 +1,9 @@
+package com.example.tinyhunt.model;
+
+/**
+ * The role a participant is currently playing.
+ */
+public enum PlayerRole {
+    RUNNER,
+    HUNTER;
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,63 @@
+players:
+  min: 2
+  max: 10
+
+# Timing values expressed in seconds.
+timers:
+  auto-start-seconds: 120
+  hunter-selection-seconds: 10
+  game-duration-seconds: 600
+
+scales:
+  runner: 0.33
+  hunter: 1.0
+
+areas:
+  lobby: {}
+  arena: {}
+
+arena-spawns: {}
+
+messages:
+  command-help: |
+    &6TinyHunt Commands:
+    &e/tinyhunt join&7 - Enter the queue.
+    &e/tinyhunt leave&7 - Leave the queue or game.
+    &e/tinyhunt lobby setpos1|setpos2&7 - Define lobby corners.
+    &e/tinyhunt arena setpos1|setpos2|addspawn&7 - Configure the arena.
+    &e/tinyhunt start&7 - Force start when ready.
+    &e/tinyhunt stop&7 - Stop the current match.
+  unknown-subcommand: "&cComando sconosciuto. Usa &e/tinyhunt&c per aiuto."
+  player-only: "&cSolo i giocatori possono usare questo comando."
+  no-permission: "&cNon hai il permesso per farlo."
+  cannot-join: "&cNon puoi unirti ora, la partita è già in corso."
+  already-queued: "&eSei già in coda."
+  queue-full: "&cLa coda è piena."
+  joined-queue: "&aEntrato in coda! Posizione: &e%position%&a."
+  left-queue: "&eHai lasciato la coda."
+  not-in-queue: "&cNon sei in coda."
+  countdown-start: "&aNumero minimo raggiunto! Avvio tra &e%seconds% &asecondi."
+  countdown-tick: "&eLa partita inizia tra &6%seconds% &esecondi."
+  countdown-cancelled: "&cConto alla rovescia annullato: giocatori insufficienti."
+  not-enough-players: "&cServono più giocatori per iniziare la partita."
+  configuration-missing: "&cConfigura lobby, arena e spawn prima di avviare il gioco."
+  game-start: "&aLa partita è iniziata!"
+  already-running: "&eUna partita è già in corso."
+  hunter-selected: "&c%player% &eè diventato l'Hunter!"
+  you-are-hunter: "&cSei l'Hunter! Caccia tutti i runner."
+  now-hunter: "&cSei stato trasformato in Hunter!"
+  runner-converted: "&c%player% &eè stato convertito in Hunter."
+  hunters-win: "&cGli Hunter hanno eliminato tutti i Runner!"
+  runners-win: "&aI Runner hanno resistito abbastanza a lungo!"
+  manual-stop: "&eLa partita è stata fermata manualmente."
+  start-requested: "&aRichiesta di avvio forzato inviata."
+  stop-requested: "&eRichiesta di stop inviata."
+  no-active-game: "&cNon c'è nessuna partita da fermare."
+  reloaded: "&aConfigurazione ricaricata."
+  usage-lobby: "&eUsa: /tinyhunt lobby setpos1|setpos2"
+  usage-arena: "&eUsa: /tinyhunt arena setpos1|setpos2|addspawn"
+  lobby-pos-set: "&aAngolo &e%corner% &adella lobby salvato."
+  arena-pos-set: "&aAngolo &e%corner% &adell'arena salvato."
+  arena-spawn-added: "&aSpawn dell'arena aggiunto."
+  game-start-runner: "&aSei un Runner! Sopravvivi agli Hunter."
+  player-left: "&e%player% ha lasciato la partita."

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,20 @@
 name: TinyHunt
 main: com.example.tinyhunt.TinyHuntPlugin
-version: 0.0.1
+version: 0.1.0
 api-version: "1.20"
 authors:
   - TinyHunt Team
-description: Base structure for the TinyHunt Paper plugin.
+description: Multiplayer Hunter vs Runner minigame with configurable lobby and arena.
+commands:
+  tinyhunt:
+    description: Gestisce il minigioco TinyHunt.
+    usage: /<command>
+    aliases: [th]
+    permission: tinyhunt.play
+permissions:
+  tinyhunt.play:
+    description: Permette di usare /tinyhunt join e /tinyhunt leave.
+    default: true
+  tinyhunt.admin:
+    description: Permette di configurare e avviare TinyHunt.
+    default: op


### PR DESCRIPTION
## Summary
- add configurable lobby and arena handling with persistent spawn locations and scaling fallback
- implement the /tinyhunt command for queue join/leave, area setup, and manual controls with auto-start countdown
- manage game flow for runners and hunters including conversion, win conditions, and configurable messaging

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e52125f2488320be5eaf9ef80f33a3