### PR TITLE
Add visual skill cooldown tracking and party chat command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,3 +17,4 @@
 - Mantieni questo file aggiornato con link utili o convenzioni scoperte durante lo sviluppo per velocizzare il lavoro futuro.
 - Il `GameManager` gestisce ora respawn ritardati (stato `CONVERTING`), la Sudden Death (ping glowing + speed ai cacciatori) e l'HUD condiviso (`MatchHud` con scoreboard e bossbar). Consulta `config.yml` per i nuovi parametri (`timers.runner-respawn-*`, sezione `sudden-death`, sezione `hud`).
 - Target API aggiornato a Paper 1.21.x (testato su 1.21.8); assicurati che le dipendenze Maven e `plugin.yml` restino allineati.
+- Moduli MMO/party sperimentali vivono sotto `com.kjaza.tinymmo`. Qui trovi `skill` (gestione abilità, cooldown sia logici che visivi) e `party` (party manager + chat rapida `/p` con listener `@`). Le classi chiave vengono istanziate in `TinyHuntPlugin` e usano `LegacyComponentSerializer` per i messaggi in actionbar.

--- a/src/main/java/com/example/tinyhunt/TinyHuntPlugin.java
+++ b/src/main/java/com/example/tinyhunt/TinyHuntPlugin.java
@@ -3,6 +3,14 @@ package com.example.tinyhunt;
 import com.example.tinyhunt.command.TinyHuntCommand;
 import com.example.tinyhunt.game.GameManager;
 import com.example.tinyhunt.game.PlayerListener;
+import com.kjaza.tinymmo.party.PartyChatCommand;
+import com.kjaza.tinymmo.party.PartyChatListener;
+import com.kjaza.tinymmo.party.PartyManager;
+import com.kjaza.tinymmo.skill.CooldownManager;
+import com.kjaza.tinymmo.skill.ResourceManager;
+import com.kjaza.tinymmo.skill.SkillListener;
+import com.kjaza.tinymmo.skill.SkillManager;
+import com.kjaza.tinymmo.skill.VisualCooldowns;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -16,22 +24,47 @@ import org.bukkit.plugin.java.JavaPlugin;
 public final class TinyHuntPlugin extends JavaPlugin {
 
     private GameManager gameManager;
+    private PartyManager partyManager;
+    private SkillManager skillManager;
+    private CooldownManager cooldownManager;
+    private ResourceManager resourceManager;
+    private VisualCooldowns visualCooldowns;
+    private int visualCooldownTaskId = -1;
 
     @Override
     public void onEnable() {
         saveDefaultConfig();
         gameManager = new GameManager(this);
+        partyManager = new PartyManager();
+        skillManager = new SkillManager(this);
+        cooldownManager = new CooldownManager();
+        resourceManager = new ResourceManager();
+        visualCooldowns = new VisualCooldowns(this);
         TinyHuntCommand tinyHuntCommand = new TinyHuntCommand(this, gameManager);
         PluginCommand command = Objects.requireNonNull(getCommand("tinyhunt"),
                 "tinyhunt command must be defined in plugin.yml");
         command.setExecutor(tinyHuntCommand);
         command.setTabCompleter(tinyHuntCommand);
         getServer().getPluginManager().registerEvents(new PlayerListener(gameManager), this);
+        getServer().getPluginManager().registerEvents(
+                new SkillListener(skillManager, cooldownManager, resourceManager, visualCooldowns, this),
+                this);
+        getServer().getPluginManager().registerEvents(new PartyChatListener(partyManager), this);
+        PluginCommand partyChatCommand = Objects.requireNonNull(getCommand("p"),
+                "p command must be defined in plugin.yml");
+        partyChatCommand.setExecutor(new PartyChatCommand(partyManager));
+        visualCooldownTaskId = getServer().getScheduler()
+                .runTaskTimer(this, () -> visualCooldowns.tickActionbar(), 10L, 10L)
+                .getTaskId();
         getLogger().info("TinyHunt plugin enabled.");
     }
 
     @Override
     public void onDisable() {
+        if (visualCooldownTaskId != -1) {
+            getServer().getScheduler().cancelTask(visualCooldownTaskId);
+            visualCooldownTaskId = -1;
+        }
         if (gameManager != null) {
             gameManager.cancelAllTasks();
         }
@@ -57,5 +90,25 @@ public final class TinyHuntPlugin extends JavaPlugin {
             message = message.replace(token, String.valueOf(entry.getValue()));
         }
         return message;
+    }
+
+    public VisualCooldowns getVisualCooldowns() {
+        return visualCooldowns;
+    }
+
+    public SkillManager getSkillManager() {
+        return skillManager;
+    }
+
+    public CooldownManager getCooldownManager() {
+        return cooldownManager;
+    }
+
+    public ResourceManager getResourceManager() {
+        return resourceManager;
+    }
+
+    public PartyManager getPartyManager() {
+        return partyManager;
     }
 }

--- a/src/main/java/com/kjaza/tinymmo/party/Party.java
+++ b/src/main/java/com/kjaza/tinymmo/party/Party.java
@@ -1,0 +1,21 @@
+package com.kjaza.tinymmo.party;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public class Party {
+    public final UUID owner;
+    public final Set<UUID> members;
+
+    public Party(UUID owner) {
+        this.owner = owner;
+        this.members = new HashSet<>();
+        this.members.add(owner);
+    }
+
+    public Set<UUID> membersView() {
+        return Collections.unmodifiableSet(members);
+    }
+}

--- a/src/main/java/com/kjaza/tinymmo/party/PartyChatCommand.java
+++ b/src/main/java/com/kjaza/tinymmo/party/PartyChatCommand.java
@@ -1,0 +1,42 @@
+package com.kjaza.tinymmo.party;
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class PartyChatCommand implements CommandExecutor {
+    private final PartyManager pm;
+
+    public PartyChatCommand(PartyManager pm) {
+        this.pm = pm;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender s, Command c, String l, String[] args) {
+        if (!(s instanceof Player p)) {
+            s.sendMessage("Solo in-game.");
+            return true;
+        }
+        Party party = pm.getPartyOf(p.getUniqueId());
+        if (party == null) {
+            p.sendMessage("§7Non sei in un party.");
+            return true;
+        }
+        if (args.length == 0) {
+            p.sendMessage("§eUso: /p <messaggio>");
+            return true;
+        }
+
+        String msg = String.join(" ", args);
+        String line = "§9[Party] §a" + p.getName() + "§7: §f" + msg;
+        for (var id : party.members) {
+            Player pl = Bukkit.getPlayer(id);
+            if (pl != null) {
+                pl.sendMessage(line);
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/kjaza/tinymmo/party/PartyChatListener.java
+++ b/src/main/java/com/kjaza/tinymmo/party/PartyChatListener.java
@@ -1,0 +1,41 @@
+package com.kjaza.tinymmo.party;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+
+public class PartyChatListener implements Listener {
+    private final PartyManager pm;
+
+    public PartyChatListener(PartyManager pm) {
+        this.pm = pm;
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onChat(AsyncPlayerChatEvent e) {
+        String msg = e.getMessage();
+        if (!msg.startsWith("@")) {
+            return;
+        }
+        Party party = pm.getPartyOf(e.getPlayer().getUniqueId());
+        if (party == null) {
+            return;
+        }
+
+        e.setCancelled(true);
+        String clean = msg.substring(1).trim();
+        if (clean.isEmpty()) {
+            return;
+        }
+        String line = "§9[Party] §a" + e.getPlayer().getName() + "§7: §f" + clean;
+        for (var id : party.members) {
+            Player pl = Bukkit.getPlayer(id);
+            if (pl != null) {
+                pl.sendMessage(line);
+            }
+        }
+    }
+}

--- a/src/main/java/com/kjaza/tinymmo/party/PartyManager.java
+++ b/src/main/java/com/kjaza/tinymmo/party/PartyManager.java
@@ -1,0 +1,59 @@
+package com.kjaza.tinymmo.party;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class PartyManager {
+    private final Map<UUID, Party> parties = new HashMap<>();
+    private final Map<UUID, UUID> playerToParty = new HashMap<>();
+
+    public Party createParty(UUID owner) {
+        Party party = new Party(owner);
+        parties.put(owner, party);
+        playerToParty.put(owner, owner);
+        return party;
+    }
+
+    public void disbandParty(UUID owner) {
+        Party party = parties.remove(owner);
+        if (party == null) {
+            return;
+        }
+        for (UUID member : party.members) {
+            playerToParty.remove(member);
+        }
+    }
+
+    public void addMember(UUID owner, UUID member) {
+        Party party = parties.get(owner);
+        if (party == null) {
+            party = createParty(owner);
+        }
+        party.members.add(member);
+        playerToParty.put(member, owner);
+    }
+
+    public void removeMember(UUID member) {
+        UUID owner = playerToParty.remove(member);
+        if (owner == null) {
+            return;
+        }
+        Party party = parties.get(owner);
+        if (party == null) {
+            return;
+        }
+        party.members.remove(member);
+        if (party.members.isEmpty()) {
+            parties.remove(owner);
+        }
+    }
+
+    public Party getPartyOf(UUID player) {
+        UUID owner = playerToParty.get(player);
+        if (owner == null) {
+            return null;
+        }
+        return parties.get(owner);
+    }
+}

--- a/src/main/java/com/kjaza/tinymmo/skill/CooldownManager.java
+++ b/src/main/java/com/kjaza/tinymmo/skill/CooldownManager.java
@@ -1,0 +1,29 @@
+package com.kjaza.tinymmo.skill;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.bukkit.entity.Player;
+
+public class CooldownManager {
+    private final Map<UUID, Map<String, Long>> map = new HashMap<>();
+
+    public boolean isOnCooldown(Player p, String skillId) {
+        Long until = map.getOrDefault(p.getUniqueId(), Map.of()).get(skillId);
+        return until != null && until > System.currentTimeMillis();
+    }
+
+    public void start(Player p, String skillId, int seconds) {
+        map.computeIfAbsent(p.getUniqueId(), k -> new HashMap<>())
+           .put(skillId, System.currentTimeMillis() + seconds * 1000L);
+    }
+
+    public int remaining(Player p, String skillId) {
+        Long until = map.getOrDefault(p.getUniqueId(), Map.of()).get(skillId);
+        if (until == null) {
+            return 0;
+        }
+        long diff = until - System.currentTimeMillis();
+        return diff > 0 ? (int) Math.ceil(diff / 1000.0) : 0;
+    }
+}

--- a/src/main/java/com/kjaza/tinymmo/skill/ResourceManager.java
+++ b/src/main/java/com/kjaza/tinymmo/skill/ResourceManager.java
@@ -1,0 +1,40 @@
+package com.kjaza.tinymmo.skill;
+
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.bukkit.entity.Player;
+
+public class ResourceManager {
+    private final Map<UUID, EnumMap<ResourceType, Integer>> pools = new HashMap<>();
+
+    public boolean tryConsume(Player player, ResourceType type, int amount) {
+        if (amount <= 0) {
+            return true;
+        }
+        EnumMap<ResourceType, Integer> map = pools.get(player.getUniqueId());
+        if (map == null || map.isEmpty()) {
+            return true;
+        }
+        int current = map.getOrDefault(type, 0);
+        if (current < amount) {
+            return false;
+        }
+        map.put(type, current - amount);
+        return true;
+    }
+
+    public void setResource(Player player, ResourceType type, int amount) {
+        pools.computeIfAbsent(player.getUniqueId(), k -> new EnumMap<>(ResourceType.class))
+                .put(type, amount);
+    }
+
+    public int getResource(Player player, ResourceType type) {
+        EnumMap<ResourceType, Integer> map = pools.get(player.getUniqueId());
+        if (map == null) {
+            return 0;
+        }
+        return map.getOrDefault(type, 0);
+    }
+}

--- a/src/main/java/com/kjaza/tinymmo/skill/ResourceType.java
+++ b/src/main/java/com/kjaza/tinymmo/skill/ResourceType.java
@@ -1,0 +1,25 @@
+package com.kjaza.tinymmo.skill;
+
+import java.util.Arrays;
+
+public enum ResourceType {
+    MANA("mana"),
+    STAMINA("stamina"),
+    ENERGY("energy");
+
+    public final String key;
+
+    ResourceType(String key) {
+        this.key = key;
+    }
+
+    public static ResourceType from(String key) {
+        if (key == null || key.isEmpty()) {
+            return MANA;
+        }
+        return Arrays.stream(values())
+                .filter(type -> type.key.equalsIgnoreCase(key) || type.name().equalsIgnoreCase(key))
+                .findFirst()
+                .orElse(MANA);
+    }
+}

--- a/src/main/java/com/kjaza/tinymmo/skill/Skill.java
+++ b/src/main/java/com/kjaza/tinymmo/skill/Skill.java
@@ -1,0 +1,57 @@
+package com.kjaza.tinymmo.skill;
+
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+public class Skill {
+    public interface SkillAction extends BiConsumer<Player, Plugin> {
+        @Override
+        void accept(Player player, Plugin plugin);
+    }
+
+    private final String id;
+    private final Material mat;
+    private final int cooldownSec;
+    private final ResourceType resource;
+    private final int cost;
+    private final SkillAction action;
+
+    public Skill(String id, Material mat, int cooldownSec, ResourceType resource, int cost,
+            SkillAction action) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.mat = Objects.requireNonNull(mat, "mat");
+        this.cooldownSec = cooldownSec;
+        this.resource = Objects.requireNonNull(resource, "resource");
+        this.cost = cost;
+        this.action = action;
+    }
+
+    public String id() {
+        return id;
+    }
+
+    public Material mat() {
+        return mat;
+    }
+
+    public int cooldownSec() {
+        return cooldownSec;
+    }
+
+    public ResourceType resource() {
+        return resource;
+    }
+
+    public int cost() {
+        return cost;
+    }
+
+    public void execute(Player player, Plugin plugin) {
+        if (action != null) {
+            action.accept(player, plugin);
+        }
+    }
+}

--- a/src/main/java/com/kjaza/tinymmo/skill/SkillListener.java
+++ b/src/main/java/com/kjaza/tinymmo/skill/SkillListener.java
@@ -1,0 +1,82 @@
+package com.kjaza.tinymmo.skill;
+
+import java.util.Optional;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.ChatColor;
+import org.bukkit.Sound;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+
+public class SkillListener implements Listener {
+    private static final LegacyComponentSerializer LEGACY_SERIALIZER =
+            LegacyComponentSerializer.legacySection();
+
+    private final SkillManager sm;
+    private final CooldownManager cm;
+    private final ResourceManager rm;
+    private final VisualCooldowns vcd;
+    private final Plugin plugin;
+
+    public SkillListener(SkillManager sm, CooldownManager cm, ResourceManager rm,
+            VisualCooldowns vcd, Plugin plugin) {
+        this.sm = sm;
+        this.cm = cm;
+        this.rm = rm;
+        this.vcd = vcd;
+        this.plugin = plugin;
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onUse(PlayerInteractEvent e) {
+        if (e.getHand() == EquipmentSlot.OFF_HAND) {
+            return;
+        }
+        ItemStack item = e.getItem();
+        Optional<Skill> skillOpt = sm.resolveSkill(item);
+        if (skillOpt.isEmpty()) {
+            return;
+        }
+        Skill skill = skillOpt.get();
+
+        if (!sm.isOwner(e.getPlayer(), item)) {
+            e.setCancelled(true);
+            return;
+        }
+
+        if (cm.isOnCooldown(e.getPlayer(), skill.id())) {
+            int rem = cm.remaining(e.getPlayer(), skill.id());
+            Component message = LEGACY_SERIALIZER.deserialize(ChatColor.RED + "Cooldown: " + rem + "s");
+            e.getPlayer().sendActionBar(message);
+            e.setCancelled(true);
+            return;
+        }
+
+        String base = "skills.costs." + skill.id() + ".";
+        ResourceType rt = ResourceType.from(
+                plugin.getConfig().getString(base + "resource", skill.resource().key));
+        int cost = plugin.getConfig().getInt(base + "amount", skill.cost());
+
+        if (!rm.tryConsume(e.getPlayer(), rt, cost)) {
+            Component message = LEGACY_SERIALIZER.deserialize(ChatColor.RED + "Non hai abbastanza "
+                    + rt.key + " (" + cost + " richiesti).");
+            e.getPlayer().sendActionBar(message);
+            e.setCancelled(true);
+            return;
+        }
+
+        skill.execute(e.getPlayer(), plugin);
+
+        cm.start(e.getPlayer(), skill.id(), skill.cooldownSec());
+        vcd.start(e.getPlayer(), skill, skill.cooldownSec());
+
+        e.getPlayer().getWorld().playSound(e.getPlayer().getLocation(),
+                Sound.UI_TOAST_CHALLENGE_COMPLETE, 1f, 1.2f);
+        e.setCancelled(true);
+    }
+}

--- a/src/main/java/com/kjaza/tinymmo/skill/SkillManager.java
+++ b/src/main/java/com/kjaza/tinymmo/skill/SkillManager.java
@@ -1,0 +1,73 @@
+package com.kjaza.tinymmo.skill;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.Plugin;
+
+public class SkillManager {
+    private final Plugin plugin;
+    private final Map<String, Skill> skills = new HashMap<>();
+    private final NamespacedKey skillKey;
+    private final NamespacedKey ownerKey;
+
+    public SkillManager(Plugin plugin) {
+        this.plugin = plugin;
+        this.skillKey = new NamespacedKey(plugin, "skill_id");
+        this.ownerKey = new NamespacedKey(plugin, "skill_owner");
+    }
+
+    public void register(Skill skill) {
+        skills.put(skill.id(), skill);
+    }
+
+    public Optional<Skill> resolveSkill(ItemStack stack) {
+        if (stack == null) {
+            return Optional.empty();
+        }
+        ItemMeta meta = stack.getItemMeta();
+        if (meta == null) {
+            return Optional.empty();
+        }
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        String id = container.get(skillKey, PersistentDataType.STRING);
+        if (id == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(skills.get(id));
+    }
+
+    public boolean isSkillItem(ItemStack stack) {
+        return resolveSkill(stack).isPresent();
+    }
+
+    public boolean isOwner(Player player, ItemStack stack) {
+        if (stack == null) {
+            return false;
+        }
+        ItemMeta meta = stack.getItemMeta();
+        if (meta == null) {
+            return false;
+        }
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        String owner = container.get(ownerKey, PersistentDataType.STRING);
+        if (owner == null) {
+            return true;
+        }
+        return owner.equalsIgnoreCase(player.getUniqueId().toString());
+    }
+
+    public NamespacedKey getSkillKey() {
+        return skillKey;
+    }
+
+    public NamespacedKey getOwnerKey() {
+        return ownerKey;
+    }
+}

--- a/src/main/java/com/kjaza/tinymmo/skill/VisualCooldowns.java
+++ b/src/main/java/com/kjaza/tinymmo/skill/VisualCooldowns.java
@@ -1,0 +1,54 @@
+package com.kjaza.tinymmo.skill;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+public class VisualCooldowns {
+    private static final LegacyComponentSerializer LEGACY_SERIALIZER =
+            LegacyComponentSerializer.legacySection();
+
+    private final Plugin plugin;
+    private final Map<UUID, Map<String, Long>> track = new HashMap<>();
+
+    public VisualCooldowns(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void start(Player p, Skill skill, int seconds) {
+        p.setCooldown(skill.mat(), seconds * 20);
+        track.computeIfAbsent(p.getUniqueId(), k -> new HashMap<>())
+             .put(skill.id(), System.currentTimeMillis() + seconds * 1000L);
+    }
+
+    public void tickActionbar() {
+        long now = System.currentTimeMillis();
+        for (Player p : Bukkit.getOnlinePlayers()) {
+            Map<String, Long> m = track.get(p.getUniqueId());
+            if (m == null || m.isEmpty()) {
+                continue;
+            }
+            String label = null;
+            int rem = Integer.MAX_VALUE;
+            for (Map.Entry<String, Long> entry : m.entrySet()) {
+                int r = (int) Math.ceil((entry.getValue() - now) / 1000.0);
+                if (r > 0 && r < rem) {
+                    rem = r;
+                    label = entry.getKey();
+                }
+            }
+            if (label != null) {
+                Component message = LEGACY_SERIALIZER.deserialize(ChatColor.GRAY + "Cooldown: "
+                        + ChatColor.WHITE + label + ChatColor.DARK_GRAY + " " + rem + "s");
+                p.sendActionBar(message);
+            }
+            m.entrySet().removeIf(en -> en.getValue() <= now);
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -11,6 +11,9 @@ commands:
     usage: /<command>
     aliases: [th]
     permission: tinyhunt.play
+  p:
+    description: Chat di party
+    usage: /p <messaggio>
 permissions:
   tinyhunt.play:
     description: Permette di usare /tinyhunt join e /tinyhunt leave.


### PR DESCRIPTION
## Summary
- add skill cooldown utilities that track logical and visual cooldowns with actionbar updates
- register the new skill listener, cooldown task, and resource managers inside the plugin
- introduce party chat command and listener with /p alias and update plugin metadata/documentation

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e61536d4c883208d00c7f4289abb18